### PR TITLE
Remove artifact deletion steps from build workflow

### DIFF
--- a/.github/workflows/build_quarto.yml
+++ b/.github/workflows/build_quarto.yml
@@ -17,12 +17,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: _site
-      - name: Delete all artifacts
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: |
-            _site
-            _freeze
       - name: Deploy Preview
         uses: nwtgck/actions-netlify@v2
         with:
@@ -73,10 +67,6 @@ jobs:
         with:
           name: _freeze
           path: _freeze
-      - name: Delete _freeze artifact
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: _freeze
       - name: Commit updated _freeze directory
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
Removed steps for deleting artifacts in the build workflow.

@mehalter do you know why those delete steps were in there? They are failing the CI but I don't have enough context to know if deleting the artifacts is really important. 